### PR TITLE
enable multi-arch build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,12 @@ jobs:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
 
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f
+
     - name: Extract metadata (tags, labels) for Docker
       id: meta
       uses: docker/metadata-action@v4
@@ -32,6 +38,7 @@ jobs:
       uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
       with:
         context: .
+        platforms: linux/amd64,linux/arm64
         push: true
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,15 @@
 # build stage
-FROM golang:1.24 AS builder
+FROM --platform=${BUILDPLATFORM} golang:1.24 AS builder
 WORKDIR /app
 COPY go.mod go.sum ./
 RUN go mod download -x
 
 COPY . .
-RUN CGO_ENABLED=0 go build -ldflags="-w -s" -o /app/eventrouter
+ARG TARGETPLATFORM
+RUN CGO_ENABLED=0 GOARCH="${TARGETPLATFORM#*/}" go build -ldflags="-w -s" -o /app/eventrouter
 
 # final stage
-FROM quay.io/prometheus/busybox-linux-amd64:latest
+FROM quay.io/prometheus/busybox-linux-${TARGETARCH}:latest
 COPY --from=builder /app/eventrouter /app/eventrouter
 COPY docs/config.json /etc/eventrouter/config.json
 


### PR DESCRIPTION
#### What this PR does / why we need it: 

Enable multi-arch build (amd64/arm64)

#### Which issue(s) this PR fixes:

- eventrouter is not working on Raspberry Pi, nor on arm instances